### PR TITLE
feat: use WordPress plugin dependency feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Contributors: steelwagstaff
 Tags: pressbooks, plugins
-Requires at least: 6.3.1
-Tested up to: 6.3.1
+Requires at least: 6.5
+Tested up to: 6.5
 Stable tag: 1.1.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/pressbooks-shortcode-handler.php
+++ b/pressbooks-shortcode-handler.php
@@ -5,6 +5,8 @@ Plugin Name: Pressbooks Shortcode Handler
 Plugin URI: https://github.com/pressbooks/pressbooks-shortcode-handler
 Description: Plugin for Pressbooks to handle additional shortcodes used by Lumen Learning.
 Version: 1.1.0
+Requires at least: 6.5
+Requires Plugins: pressbooks
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Text Domain: pressbooks-shortcode-handler


### PR DESCRIPTION
WordPress 6.5 (coming Tuesday) introduces [plugin dependencies](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/).