### PR TITLE
fix: wrap string for translation

### DIFF
--- a/pressbooks-shortcode-handler.php
+++ b/pressbooks-shortcode-handler.php
@@ -91,7 +91,9 @@ function glossaryDefinitionShortcodeHandler( $atts = [], $content = null ) {
  */
 function videopickerShortcodeHandler( $atts = [], $content = null ) {
 	return '<div class="textbox interactive-content">
-	<p><span class="interactive-content__icon"></span>An interactive video picker element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.</p>
+	<p><span class="interactive-content__icon"></span>' 
+	. esc_html__( 'An interactive video picker element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.', 'pressbooks-shortcode-handler' ) 
+	. '</p>
 	</div>';
 }
 
@@ -118,7 +120,9 @@ function choosedatasetShortcodeHandler( $atts = [], $content = null ) {
 	return '<div id="' . $id . '" class="chooseDataset">
             ' . $header . '
             <div class="textbox interactive-content">
-	<p><span class="interactive-content__icon"></span>An interactive dataset picker element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.</p>
+	<p><span class="interactive-content__icon"></span>' 
+	. esc_html__( 'An interactive dataset picker element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.', 'pressbooks-shortcode-handler' ) 
+	. '</p>
 	</div></div>';
 }
 
@@ -130,6 +134,8 @@ function choosedatasetShortcodeHandler( $atts = [], $content = null ) {
  */
 function ohmQuestionShortcodeHandler( $atts = [], $content = null ) {
 	return '<div class="textbox interactive-content">
-	<p><span class="interactive-content__icon"></span>An interactive online homework element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.</p>
+	<p><span class="interactive-content__icon"></span>' 
+	. esc_html__( 'An interactive online homework element has been excluded from the printed version of the text. To see the interactive element that was excluded, please visit the courseware online.', 'pressbooks-shortcode-handler' ) 
+	. '</p>
 	</div>';
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2455

This pull request updates the way exclusion messages for interactive elements are handled in the `pressbooks-shortcode-handler.php` file. The main improvement is that these messages are now wrapped in a translation function, making them translatable for internationalization.

**Internationalization improvements:**

* Updated the exclusion message in the `videopickerShortcodeHandler` to use `esc_html__()` for translation support.
* Updated the exclusion message in the `choosedatasetShortcodeHandler` to use `esc_html__()` for translation support.
* Updated the exclusion message in the `ohmQuestionShortcodeHandler` to use `esc_html__()` for translation support.