### PR TITLE
chore: crowdin integration

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,57 @@
+name: Crowdin Translations Sync
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'languages/pressbooks-shortcode-handler.pot'
+
+  schedule:
+    - cron: '0 0 * * *'
+
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        type: choice
+        options:
+          - Pull Translations
+          - Seed Translations
+        default: Pull Translations
+
+jobs:
+  upload-sources:
+    name: Upload Sources
+    if: github.event_name == 'push'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: upload
+      pot_file_path: languages/pressbooks-shortcode-handler.pot
+      crowdin_branch_name: pressbooks-shortcode-handler
+      base_branch: dev
+    secrets: inherit
+
+  download-translations:
+    name: Pull Translations
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Pull Translations')
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: download
+      pot_file_path: languages/pressbooks-shortcode-handler.pot
+      languages_dir: languages/
+      crowdin_branch_name: pressbooks-shortcode-handler
+      base_branch: dev
+    secrets: inherit
+
+  seed-translations:
+    name: Seed Translations
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Seed Translations'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: seed
+      pot_file_path: languages/pressbooks-shortcode-handler.pot
+      languages_dir: languages/
+      crowdin_branch_name: pressbooks-shortcode-handler
+      base_branch: dev
+    secrets: inherit

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,19 @@
+"project_id_env": "CROWDIN_OPEN_PROJECT_ID"
+"api_token_env": "CROWDIN_API_SECRET"
+"pull_request_title": "chore(l10n): update languages"
+"preserve_hierarchy": true
+"files": [
+  {
+    "source": "/languages/pressbooks-shortcode-handler.pot",
+    "dest": "/languages/pressbooks-shortcode-handler.pot",
+    "translation": "/languages/pressbooks-shortcode-handler-%locale_with_underscore%.po",
+    "languages_mapping": {
+      "locale_with_underscore": {
+        "es-ES": "es_ES",
+        "es-MX": "es_MX",
+        "fr": "fr_FR",
+        "fr-CA": "fr_CA"
+      }
+    }
+  }
+]

--- a/languages/pressbooks-shortcode-handler.pot
+++ b/languages/pressbooks-shortcode-handler.pot
@@ -1,0 +1,40 @@
+# Copyright (C) 2026 Pressbooks (Book Oven Inc.)
+# This file is distributed under the GPL v3 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Pressbooks Shortcode Handler 1.2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-analytics/issues\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-05-19T09:52:12+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.13.0-alpha\n"
+"X-Domain: pressbooks-shortcode-handler\n"
+
+#. Plugin Name of the plugin
+#: pressbooks-shortcode-handler.php
+msgid "Pressbooks Shortcode Handler"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: pressbooks-shortcode-handler.php
+msgid "https://github.com/pressbooks/pressbooks-shortcode-handler"
+msgstr ""
+
+#. Description of the plugin
+#: pressbooks-shortcode-handler.php
+msgid "Plugin for Pressbooks to handle additional shortcodes used by Lumen Learning."
+msgstr ""
+
+#. Author of the plugin
+#: pressbooks-shortcode-handler.php
+msgid "Pressbooks (Book Oven Inc.)"
+msgstr ""
+
+#. Author URI of the plugin
+#: pressbooks-shortcode-handler.php
+msgid "https://pressbooks.org"
+msgstr ""

--- a/pressbooks-shortcode-handler.php
+++ b/pressbooks-shortcode-handler.php
@@ -23,6 +23,10 @@ add_shortcode( 'ohm', 'ohmQuestionShortcodeHandler' );
 add_shortcode( 'ohm2_question', 'ohmQuestionShortcodeHandler' );
 add_shortcode( 'choosedataset', 'choosedatasetShortcodeHandler' );
 
+add_action( 'init', function() {
+	load_plugin_textdomain( 'pressbooks-shortcode-handler', false, 'pressbooks-shortcode-handler/languages' );
+} );
+
 /**
  * Shortcode handler for [reveal-answer].
  * Ex: [reveal-answer q="153"]Show Answer[/reveal-answer].


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2454

This pull request introduces automated Crowdin translation syncing to the project and adds initial localization support for the Pressbooks Shortcode Handler plugin. The main changes include a new GitHub Actions workflow for Crowdin integration, configuration for Crowdin project mapping, the addition of a `.pot` template file, and loading of the plugin text domain for translations.

**Crowdin Integration and Workflow Automation:**

* Added `.github/workflows/crowdin.yml` to automate source upload, translation download, and seeding via Crowdin, triggered on relevant events and with workflow dispatch options.
* Introduced `crowdin.yml` for Crowdin CLI configuration, mapping source and translation files, and specifying language code mappings.

**Localization Support:**

* Added `languages/pressbooks-shortcode-handler.pot` as the template for translations, including plugin strings and metadata.
* Updated `pressbooks-shortcode-handler.php` to load the plugin text domain on `init`, enabling translation support.